### PR TITLE
Dialogue box first implementation

### DIFF
--- a/Dialogue/DialogueBox.gd
+++ b/Dialogue/DialogueBox.gd
@@ -5,36 +5,55 @@ enum {
 	STOPPED
 }
 
-onready var timer = $Timer
+onready var timer = $DialogueTimer
+onready var lockoutTimer = $DialogueLockout
 onready var panel = $Panel
 onready var dialogueBox = $Panel/HBoxContainer/Dialogue
 
+const DIALOGUE_STRING = "speech"
+var dialogue_is_locked = true
 var page = 0
 var state = STOPPED
 var dialogue = {}
 	
 func _process(delta):
 	if state == STARTED:
-		if Input.is_action_just_pressed("ui_accept"):
+		dialogueBox.visible_characters += 1
+		
+		if Input.is_action_just_pressed("ui_accept") and !dialogue_is_locked:
 			if dialogue_line_not_completed():
-				dialogueBox.visible_characters = dialogue[str(page)]["dialogue"].length()
+				dialogueBox.visible_characters = dialogue[str(page)][DIALOGUE_STRING].length()
 			else: 
 				page += 1
 				if page >= dialogue.size():
-					panel.visible = false
+					state = STOPPED
+					self.visible = false
 				else:
 					nextPage()
 
 func nextPage() -> void:
 	dialogueBox.visible_characters = 0
-	dialogueBox.text = dialogue[str(page)]["dialogue"]
+	dialogueBox.text = dialogue[str(page)][DIALOGUE_STRING]
 	
 func dialogue_line_not_completed() -> bool:
-	return dialogueBox.visible_characters < dialogue[str(page)]["dialogue"].length()
+	return dialogueBox.visible_characters < dialogue[str(page)][DIALOGUE_STRING].length()
 	
-func _dialogue_Started( dialogue ):
-	self.visible = true
-	print(dialogue)
+func _dialogue_Started( dialogue : Dictionary ) -> void:
+	init_dialogue(dialogue)
 	
 func _on_Timer_timeout():
 	dialogueBox.visible_characters += 1
+	
+func _on_DialogueLockout_timeout():
+	self.dialogue_is_locked = false
+	
+func init_dialogue( dialogue : Dictionary ):
+	if state == STOPPED:
+		page = 0
+		dialogueBox.visible_characters = 0
+		self.visible = true
+		self.dialogue = dialogue
+		self.dialogueBox.text = self.dialogue["0"][DIALOGUE_STRING]
+		state = STARTED
+		dialogue_is_locked = true
+		lockoutTimer.start()

--- a/Dialogue/DialogueBox.gd
+++ b/Dialogue/DialogueBox.gd
@@ -1,29 +1,29 @@
 extends Control
-class_name DialogueBox 
 
-var dialogue = {
-	"0": {"dialogue":"This is the first test dialogue line..."},
-	"1": {"dialogue":"This is the second line!"}
+enum {
+	STARTED,
+	STOPPED
 }
 
 onready var timer = $Timer
-var page = 0
 onready var panel = $Panel
 onready var dialogueBox = $Panel/HBoxContainer/Dialogue
 
-func _ready():
-	dialogueBox.text = dialogue[str(page)]["dialogue"]
+var page = 0
+var state = STOPPED
+var dialogue = {}
 	
 func _process(delta):
-	if Input.is_action_just_pressed("ui_accept"):
-		if dialogue_line_not_completed():
-			dialogueBox.visible_characters = dialogue[str(page)]["dialogue"].length()
-		else: 
-			page += 1
-			if page >= dialogue.size():
-				panel.visible = false
-			else:
-				nextPage()
+	if state == STARTED:
+		if Input.is_action_just_pressed("ui_accept"):
+			if dialogue_line_not_completed():
+				dialogueBox.visible_characters = dialogue[str(page)]["dialogue"].length()
+			else: 
+				page += 1
+				if page >= dialogue.size():
+					panel.visible = false
+				else:
+					nextPage()
 
 func nextPage() -> void:
 	dialogueBox.visible_characters = 0
@@ -31,6 +31,10 @@ func nextPage() -> void:
 	
 func dialogue_line_not_completed() -> bool:
 	return dialogueBox.visible_characters < dialogue[str(page)]["dialogue"].length()
+	
+func _dialogue_Started( dialogue ):
+	self.visible = true
+	print(dialogue)
 	
 func _on_Timer_timeout():
 	dialogueBox.visible_characters += 1

--- a/Dialogue/DialogueBox.tscn
+++ b/Dialogue/DialogueBox.tscn
@@ -34,7 +34,12 @@ margin_bottom = 27.0
 text = "some plain text example"
 percent_visible = 0.0
 
-[node name="Timer" type="Timer" parent="."]
+[node name="DialogueTimer" type="Timer" parent="."]
 wait_time = 0.02
 autostart = true
-[connection signal="timeout" from="Timer" to="." method="_on_Timer_timeout"]
+
+[node name="DialogueLockout" type="Timer" parent="."]
+wait_time = 0.3
+one_shot = true
+[connection signal="timeout" from="DialogueTimer" to="." method="_on_Timer_timeout"]
+[connection signal="timeout" from="DialogueLockout" to="." method="_on_DialogueLockout_timeout"]

--- a/Dialogue/DialogueLoader.tscn
+++ b/Dialogue/DialogueLoader.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://Dialogue/DialogueLoader.gd" type="Script" id=1]
+
+[node name="DialogueLoader" type="Node"]
+script = ExtResource( 1 )

--- a/Dialogue/testDialogue.json
+++ b/Dialogue/testDialogue.json
@@ -13,5 +13,10 @@
     {
       "character": "test",
       "speech": "I mean, you are reading this, right?"
+    },  
+  "3":
+    {
+      "character": "test",
+      "speech": "Adding new lines of dialogue is easy too! But I wonder what will happen if I make the line very long... like this for example! Wow, that's a lot to read..."
     }
 }

--- a/World.tscn
+++ b/World.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=61 format=2]
+[gd_scene load_steps=62 format=2]
 
 [ext_resource path="res://World/Bush.tscn" type="PackedScene" id=1]
 [ext_resource path="res://Player/Player.tscn" type="PackedScene" id=2]
@@ -11,6 +11,7 @@
 [ext_resource path="res://UI/HealthUI.tscn" type="PackedScene" id=9]
 [ext_resource path="res://World/Tree.tscn" type="PackedScene" id=10]
 [ext_resource path="res://Player/Camera2D.tscn" type="PackedScene" id=11]
+[ext_resource path="res://Dialogue/DialogueBox.tscn" type="PackedScene" id=12]
 
 [sub_resource type="TileSet" id=1]
 0/name = "DirtTileset"
@@ -644,12 +645,17 @@ position = Vector2( 96, 192 )
 [node name="Tree4" parent="Node2D/Trees" instance=ExtResource( 10 )]
 position = Vector2( 64, 192 )
 
-[node name="CanvasLayer" type="CanvasLayer" parent="."]
+[node name="UI" type="CanvasLayer" parent="."]
 
-[node name="HealthUI" parent="CanvasLayer" instance=ExtResource( 9 )]
+[node name="DialogueBox" parent="UI" instance=ExtResource( 12 )]
+visible = false
+
+[node name="HealthUI" parent="UI" instance=ExtResource( 9 )]
 margin_left = 5.0
 margin_top = 5.0
 margin_right = 53.0
 margin_bottom = 45.0
 
 [editable path="Camera2D"]
+
+[editable path="Node2D/SignPost"]

--- a/World.tscn
+++ b/World.tscn
@@ -490,6 +490,7 @@ points = PoolVector2Array( 0, 0, 32, 0, 32, 32, 0, 32 )
 [node name="World" type="Node2D"]
 
 [node name="Background" type="Sprite" parent="."]
+position = Vector2( 1, 0 )
 scale = Vector2( 1.00097, 1 )
 texture = ExtResource( 3 )
 offset = Vector2( 160, 90 )
@@ -608,15 +609,15 @@ position = Vector2( 64, 32 )
 position = Vector2( 184, 64 )
 
 [node name="Bat" parent="Node2D" instance=ExtResource( 8 )]
-position = Vector2( 232, 32 )
+position = Vector2( -104, 24 )
 scale = Vector2( 1.00097, 1 )
 
 [node name="Bat2" parent="Node2D" instance=ExtResource( 8 )]
-position = Vector2( 48, 96 )
+position = Vector2( -104, 56 )
 scale = Vector2( 1.00097, 1 )
 
 [node name="Bat3" parent="Node2D" instance=ExtResource( 8 )]
-position = Vector2( 200, 160 )
+position = Vector2( -112, 88 )
 scale = Vector2( 1.00097, 1 )
 
 [node name="Trees" type="YSort" parent="Node2D"]

--- a/World/Grass.tscn
+++ b/World/Grass.tscn
@@ -17,7 +17,6 @@ offset = Vector2( -8, -8 )
 
 [node name="HurtBox" parent="." instance=ExtResource( 3 )]
 collision_layer = 8
-show_hit = false
 
 [node name="CollisionShape2D" parent="HurtBox" index="0"]
 position = Vector2( 8, 8 )

--- a/World/SignPost.gd
+++ b/World/SignPost.gd
@@ -1,17 +1,23 @@
 extends StaticBody2D
 
-var dialogueLoader = load("res://Dialogue/DialogueLoader.gd").new()
+onready var dialogueLoader = $DialogueLoader
 
 export var dialogue_path : String
+var dialogue = "no dialogue yet defined"
 var player_in_activation_zone : bool = false
+var dialogueBox
+
+signal dialogueStarted
 
 func _ready():
-	var dialogue = dialogueLoader.load_dialogue(dialogue_path)
-	print(dialogue)
+	# feels like a hack... what if the path changes?
+	dialogueBox = get_tree().current_scene.get_node("/root/World/UI/DialogueBox")
+	dialogue = dialogueLoader.load_dialogue(dialogue_path)
+	connect( "dialogueStarted", dialogueBox, "_dialogue_Started" )
 	
 func _physics_process(_delta):
 	if player_in_activation_zone and Input.is_action_just_pressed("ui_accept"):
-		print( "in activation zone and activated!" )
+		emit_signal("dialogueStarted", dialogue)
 
 func _on_ActivationZone_body_entered(_body):
 	player_in_activation_zone = true

--- a/World/SignPost.tscn
+++ b/World/SignPost.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://World/SignPost.png" type="Texture" id=1]
 [ext_resource path="res://World/SignPost.gd" type="Script" id=2]
+[ext_resource path="res://Dialogue/DialogueLoader.tscn" type="PackedScene" id=3]
 
 [sub_resource type="CapsuleShape2D" id=1]
 radius = 4.0
@@ -31,5 +32,9 @@ collision_mask = 2
 [node name="CollisionZone" type="CollisionShape2D" parent="ActivationZone"]
 position = Vector2( 0, 3 )
 shape = SubResource( 2 )
+
+[node name="DialogueLoader" parent="." instance=ExtResource( 3 )]
 [connection signal="body_entered" from="ActivationZone" to="." method="_on_ActivationZone_body_entered"]
 [connection signal="body_exited" from="ActivationZone" to="." method="_on_ActivationZone_body_exited"]
+
+[editable path="DialogueLoader"]

--- a/project.godot
+++ b/project.godot
@@ -8,14 +8,9 @@
 
 config_version=4
 
-_global_script_classes=[ {
-"base": "Control",
-"class": "DialogueBox",
-"language": "GDScript",
-"path": "res://Dialogue/DialogueBox.gd"
-} ]
+_global_script_classes=[  ]
 _global_script_class_icons={
-"DialogueBox": ""
+
 }
 
 [application]

--- a/project.godot
+++ b/project.godot
@@ -57,6 +57,14 @@ texture={
 
 [input]
 
+ui_accept={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777222,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":69,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
+ ]
+}
 ui_left={
 "deadzone": 0.5,
 "events": [ Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)


### PR DESCRIPTION
**DialogueLoader**: 
loads dialogue from a JSON source and returns it as a Dictionary

**SignPost**: 
contains a dialogue loader, and grabs returned Dictionary and signals it up to the UI layer to the DialogueBox

**DialogueBox**: 
handles all things dialogue. when receiving a signal, parses dictionary and displays it incrementally on screen

**TODOS:**

- State management to freeze all entities in the world, or somehow pause all entities from moving while player is reading
- Add support for longer lines of dialogue (probably to a limit, don't want to overcrowd)
- Add character portraits to dialogue boxs based on JSON dialogue file passed
- Create sprite for dialogue box to make it look cleaner